### PR TITLE
Removed -r flag from cp invokation to copy tikz-er2.sty to the install dir

### DIFF
--- a/latex-tikz-er2/PKGBUILD
+++ b/latex-tikz-er2/PKGBUILD
@@ -14,7 +14,7 @@ md5sums=('9ae0d6eceb67b192d20a8504122cea38')
 
 package() {
     install -dm755 "${pkgdir}/usr/share/texmf-dist/tex/latex/tikz-er2"
-    cp -r tikz-er2.sty "${pkgdir}/usr/share/texmf-dist/tex/latex/tikz-er2"
+    cp tikz-er2.sty "${pkgdir}/usr/share/texmf-dist/tex/latex/tikz-er2"
 
     cd "${pkgdir}/usr/share/texmf-dist/tex/latex/"
     find . -type d -exec chmod 755 {} \;


### PR DESCRIPTION
(Quick preface, I don't have any experience writing PKGBUILDs, so if this is in violation of good practices, let me know)

So, `cp` dereferences symbolic links by default, but `cp -r` _does not_. Some pacman extensions like `yaourt`, which I use, will stage build files in a tmp directory as symlinks, though I don't know if that's default behavior or a byproduct of `install` or something. Regardless, when I used this, it copied the symlink to `tikz-er2.sty` and then promptly removed the original. Problematic!

Since we're just copying a single file, the `-r` isn't useful, so I removed it. Improves compatibility.
